### PR TITLE
Check if Perl supports threads, if not, then --no-threads is forced

### DIFF
--- a/program/whohas
+++ b/program/whohas
@@ -37,8 +37,9 @@ use sigtrap;
 #TODO deal gracefully with hyphens that may be present in some distros but not others, i.e. include extra hyphens in regexes, and allow user-specified hyphens to be absent
 #TODO fix opensuse
 
+use Config;
 use Env qw(HOME);
-use threads;
+use if $Config{usethreads}, "threads";
 use Getopt::Long;
 
 my $confdir = "$HOME/.whohas";
@@ -91,6 +92,11 @@ if (@ARGV > 1) {
 	die "Error:\tToo many parameters. Usage: $0 [--no-threads] [--shallow] [--strict] [-d Dist1[,Dist2[,Dist3...]]] pkgname\n";
 } elsif (@ARGV < 1) {
 	die "Error:\tPlease specify a search term.\n";
+}
+
+if (!$Config{usethreads} && !$nothreads) {
+	$nothreads = 1;
+	warn "No threads support, --no-threads is forced.\n";
 }
 
 #


### PR DESCRIPTION
I am not a Perl coder, this is my first time tried to code in Perl, so this PR might not be good.

My Perl is 5.16.3 and my Linux is Gentoo, which doesn't have threads support by default, meaning most Gentoo users don't have threads support unless they enable with USE flag. I didn't even know about it until I ran whohas and saw the warning from Perl, without threads support even `-h` breaks:

``` sh
$ perl program/whohas -h
This Perl not built to support threads
Compilation failed in require at program/whohas line 41.
BEGIN failed--compilation aborted at program/whohas line 41.
```

This is main reason why I wanted to make this PR.
