### PR TITLE
Parse available Fedora versions, default to most recent three

### DIFF
--- a/whohas
+++ b/whohas
@@ -54,8 +54,8 @@ unless (-d $confdir) {
 my @columns = (11,38,18,4,10,25);
 my $cols = 6;
 
-our $fedora_min_release		 =  26			;
-our $fedora_max_release		 =  27			;
+our $fedora_min_release		 =  ""			;
+our $fedora_max_release		 =  ""			;
 our $debian_current_release	 = "all"		;
 our $ubuntu_current_release	 = "all"		;
 our $openbsd_release		 = "6.0"		;
@@ -194,6 +194,26 @@ sub fedora {
 	my @sizes;
 	my @repos;
 	my @urls;
+
+	if (not $fedora_max_release) {
+		my @lines = split /\n/, &fetchdoc($baseurl);
+		for (my $li = 0; $li < @lines; $li++) {
+			if ($lines[$li] =~ m{<img src="[^"]*folder[^"]*" alt="[^"]*"> *<a href="[0-9]+/"}) {
+				my ($release) = ($lines[$li] =~ m{<img src="[^"]*folder[^"]*" alt="[^"]*"> *<a href="([0-9]+)/"});
+				if ($release > $fedora_max_release) {
+					$fedora_max_release = $release;
+				}
+			}
+		}
+		if (not $fedora_max_release) {
+			print STDERR "Could not parse Fedora release list, skipping Fedora packages\n";
+			return ();
+		}
+	}
+	if (not $fedora_min_release) {
+		$fedora_min_release = $fedora_max_release - 2;
+	}
+
 	for (my $i = $fedora_max_release; $i >= $fedora_min_release; $i--) {
 		my @fed_urls = ("$i/Everything/$arch/os/Packages/");
 		my $file = "$confdir/$distroname\_$i.list";

--- a/whohas.cf
+++ b/whohas.cf
@@ -9,8 +9,11 @@
 # Versioning information.
 #
 
-#$fedora_min_release = 26;
-#$fedora_max_release = 27;
+# For Fedora, a blank value for max defaults parsing the website for available versions.
+# A blank value for min defaults to (max - 2).
+#$fedora_min_release = '';
+#$fedora_max_release = '';
+
 #$debian_current_release = 'all';
 #$ubuntu_current_release = 'all';
 #$openbsd_release = '6.0';


### PR DESCRIPTION
There is a REST API which could be parsed to check whether the latest is
released or merely in development, but I'd already written the screen-scraper
before finding that. If a website change breaks this, then the package-version
parsing will probably break at the same time anyway.

The page website's $baseurl contains lines such as
```
    <img src="/icons/folder.gif" alt="[DIR]"> <a href="11/">11/</a>                     2013-04-25 08:48    -
```