### PR TITLE
Updated Arch support, use JSON APIs

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,6 @@ date
 Perl Modules
 ------------
 LWP::UserAgent (usually packaged as libwww-perl or perl-libwww, depending on distribution)
-forks
 Thread::Queue
 Sys::CPU (optional)
 

--- a/INSTALL
+++ b/INSTALL
@@ -12,6 +12,10 @@ LWP::UserAgent (usually packaged as libwww-perl or perl-libwww, depending on dis
 Thread::Queue
 Sys::CPU (optional)
 
+For fetching Archlinux/AUR information you also need:
+LWP::Protocol::https (usually packaged as perl-lwp-protocol-https, depending on distribution)
+JSON (usually packaged as perl-json, depending on distribution)
+
 
 To install
 ==========

--- a/whohas
+++ b/whohas
@@ -968,9 +968,8 @@ sub debuntu {
 }
 
 sub aur {
-	my $aurbase    = "http://aur.archlinux.org";
-	my $stop;
-	my @lines = split /\n/, &fetchdoc($aurbase."/packages.php?SeB=n&PP=1000&K=".$_[0]); # 1000 should be enough
+	my $aurbase    = "https://aur.archlinux.org";
+	my @lines = split /\n/, &fetchdoc($aurbase."/rpc/?v=5&type=search&arg=".$_[0]);
 
 	my @repos;
 	my @names;
@@ -978,21 +977,24 @@ sub aur {
 	my @dates;
 	my @urls;
 	my @sizes;
-	my $indicator = 0;
-	for (my $i = 100; $i < @lines; $i++) {  # 100 is a compromise between safety and efficiency
-		if ($lines[$i] =~ /<tr class=["'](?:odd|even)/) {
-			for (my $a = 2; $a < 7;$a++) {
-				my $temp = $lines[$a+$i];
-				$temp =~ s/.*\<td[^>]*\>|\<\/td\>//g;
-				if ($a == 2) {
-					push @urls, $aurbase.&arch_site_get_url ($lines[$i+$a]);
-					push @names, &arch_site_ger_cont($lines[$i+$a]);
-				} elsif ($a == 3) {
-					push @versions, $temp;
+	for (my $i = 0; $i < @lines; $i++) {
+		if ($lines[$i] =~ /\{/) {
+			my $content = decode_json($lines[$i]);
+			if ($content->{version} != 5 ) {
+				warn ("Unknown version");
+				return ();
+			}
+			for (my $i = 0; $i < @{$content->{results}}; $i++) {
+				my $pkg = $content->{results}[$i];
+				if ($pkg->{Name} =~ $_[0]) {
+					# push @repos, # there are no "repos" in AUR
+					push @names, $pkg->{Name};
+					push @versions, $pkg->{Version}; # XXX: Versions can be too long
+					# push @sizes, # not build so size is unknown
+					# push @dates, # not build so date is unknown
+					push @urls, "$aurbase/packages/$pkg->{Name}";
 				}
 			}
-			# 1 is section, 4 is votes, 5 is description, 7 is maintainer
-			$i += 7;
 		}
 	}
 	for (my $i = 0; $i < @names; $i++) {

--- a/whohas
+++ b/whohas
@@ -141,6 +141,7 @@ my $q = Thread::Queue->new();
 foreach (keys %distrosSelected) {
 	if ($distrosSelected{$_}) {
 		if ($_ eq 'arch') {
+			use JSON;
 			$q->enqueue('arch', 'aur');
 		} else {
 			$q->enqueue($_);
@@ -1000,10 +1001,21 @@ sub aur {
 	return ();
 }
 
+sub human {
+        my $size = $_[0];
+	my @suffixes = (' ', 'K', 'M', 'G');
+	my $index = 0;
+
+	while ($size > 1024) {
+		$index++;
+		$size = POSIX::floor($size / 1024);
+	}
+	return("$size@suffixes[$index]");
+}
+
 sub arch {
-	my $archbase   = "http://www.archlinux.org";
-	# if we directly query i686, redirected to the specific package page
-	my @lines = split /\n/, &fetchdoc($archbase."/packages/?q=".$_[0]);
+	my $archbase   = "https://www.archlinux.org";
+	my @lines = split /\n/, &fetchdoc($archbase."/packages/search/json/?q=".$_[0]);
 
 	my @repos;
 	my @names;
@@ -1012,24 +1024,27 @@ sub arch {
 	my @urls;
 	my @sizes;
 	for (my $i = 0; $i < @lines; $i++) {
-		if ($lines[$i] =~ /\<tr class\=["'](?:odd|even)/) {
-			for (my $a = 2; $a < 11;$a++) {
-				my $temp = $lines[$a+$i];
-				$temp =~ s/.*\<td\>|\<\/td\>//g;
-				if ($a == 3) {
-					push @repos,$temp;
-				} elsif ($a == 4) {
-					push @urls, $archbase.&arch_site_get_url ($lines[$i+$a]);
-					push @names, &arch_site_ger_cont($lines[$i+$a]);
-				} elsif ($a == 6) {
-					push @versions, $temp;
-				} elsif ($a == 9) {
-					push @dates,    $temp;
+		if ($lines[$i] =~ /\{/) {
+			my $content = decode_json($lines[$i]);
+			if ($content->{version} != 2 ) {
+				warn ("Unknown version");
+				return ();
+			}
+			for (my $i = 0; $i < @{$content->{results}}; $i++) {
+				my $pkg = $content->{results}[$i];
+				if ($pkg->{pkgname} =~ $_[0]) {
+					push @repos, $pkg->{repo};
+					push @names, $pkg->{pkgname};
+					my $epoch = "";
+					if ($pkg->{epoch} != 0) {
+						$epoch = "$pkg->{epoch}:";
+					}
+					push @versions, "$epoch$pkg->{pkgver}-$pkg->{pkgrel}";
+					push @sizes, human($pkg->{compressed_size}); # XXX: there is also installed_size
+					push @dates, $pkg->{build_date};
+					push @urls, $pkg->{url};
 				}
 			}
-			# 2 is architecture, 8 is description
-			push @sizes, "";
-			$i += 7;
 		}
 	}
 	for (my $i = 0; $i < @repos; $i++) {

--- a/whohas
+++ b/whohas
@@ -38,7 +38,6 @@ use sigtrap;
 
 use Config;
 use Env qw(HOME);
-use if $^O ne 'MSWin32', 'forks';
 use if $Config{usethreads}, "threads";
 use Getopt::Long;
 use LWP::UserAgent;


### PR DESCRIPTION
Replace the existing screen-scraping with the JSON APIs that Arch provides.
There's one for the official package and different one for the user repos aka AUR.

Since there is no `Forks` on Arch, I've removed it all together - hope it's not too controversial.
Alternatively, I'm open to suggestions how to make it optional, ideally without pulling additional modules.

Thanks