### PR TITLE
Make the forks module optional

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ date
 Perl Modules
 ------------
 LWP::UserAgent (usually packaged as libwww-perl or perl-libwww, depending on distribution)
-forks
+forks (optional)
 Thread::Queue
 Sys::CPU (optional)
 

--- a/whohas
+++ b/whohas
@@ -38,7 +38,9 @@ use sigtrap;
 
 use Config;
 use Env qw(HOME);
-use if $^O ne 'MSWin32', 'forks';
+eval {
+	require if $^O ne 'MSWin32', 'forks';
+};
 use if $Config{usethreads}, "threads";
 use Getopt::Long;
 use LWP::UserAgent;


### PR DESCRIPTION
While the module decreases memory usage (since allegedrly Perl threads
are very memory hungry) the module is not as widely available. For
example it's missing on Arch.
    
So replace the current use with eval/require combo for the forks module,
thus making it optional.

Note: this has been tested on Arch w/o forks. Please test this on distro where the module is available.