### PR TITLE
Mandriva -> Mageia

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -18,7 +18,7 @@
 <p><a href="html_assets/screenshot.jpg"><img border=0 src="html_assets/screenshot.jpg" width="500px"></a></p>
 <h2>whohas</h2>
 <h3>Description</h3>
-<p>whohas is a command line tool that allows querying several package lists at once - currently supported are Arch, Debian, Fedora, Gentoo, Mandriva, openSUSE, Slackware, Source Mage, Ubuntu, FreeBSD, NetBSD, OpenBSD, Fink, MacPorts and Cygwin. whohas is written in Perl and was designed to help package maintainers find ebuilds, pkgbuilds and similar package definitions from other distributions to learn from. However, it can also be used by normal users who want to know:</p>
+<p>whohas is a command line tool that allows querying several package lists at once - currently supported are Arch, Debian, Fedora, Gentoo, Mageia, openSUSE, Slackware, Source Mage, Ubuntu, FreeBSD, NetBSD, OpenBSD, Fink, MacPorts and Cygwin. whohas is written in Perl and was designed to help package maintainers find ebuilds, pkgbuilds and similar package definitions from other distributions to learn from. However, it can also be used by normal users who want to know:</p>
 <ul>
 <li>Which distribution provides packages on which the user depends.</li>
 <li>What version of a given package is in use in each distribution, or in each release of a distribution (implemented only for Debian).</li>
@@ -35,7 +35,7 @@
 <p>The spaces will ensure that only results for the package gimp are displayed, not for gimp-print etc.</p>
 <p>If you want results for a particular distribution only, do</p>
 <p class=code>whohas arch | grep "^Arch"</p>
-<p>Output for each module will still be ordered, so you don't need to sort results in this case, although you may wish to do so for some distributions. Distribution names are abbreviated as "Arch", "Debian", "Fedora", "Gentoo", "Mandriva", "openSUSE", "Slackware", "Source Mage", "FreeBSD", "NetBSD", "OpenBSD", "Fink", "MacPorts", and "Cygwin".</p>
+<p>Output for each module will still be ordered, so you don't need to sort results in this case, although you may wish to do so for some distributions. Distribution names are abbreviated as "Arch", "Debian", "Fedora", "Gentoo", "Mageia", "openSUSE", "Slackware", "Source Mage", "FreeBSD", "NetBSD", "OpenBSD", "Fink", "MacPorts", and "Cygwin".</p>
 <p>Output in version 0.1 <a href="output0.txt">looked like this</a>. The first column is the name of the distribution, the second the name of the package, the third the version number, then the date, repository name and a url linking to more information about the package. Future versions will have package size information, too. Column lengths are fixed, so you can use cut:</p>
 <p class=code>whohas vim | grep " vim " | cut -b 38-47</p>
 <p>The first bytes of the data fields at the time of writing are 0, 11, 49, 67, 71, 81 and 106.</p>

--- a/usr/share/man/de/man1/whohas.1
+++ b/usr/share/man/de/man1/whohas.1
@@ -7,7 +7,7 @@ whohas \- findet Pakete in verschiedenen Repositories
 whohas [\fI\-\-no\-threads\fP] [\fI\-\-shallow\fP] [\fI\-\-strict\fP] [\fI\-d Dist1[,Dist2[,Dist3 etc.]]\fP] \fIpkgname\fP
 .SH "BESCHREIBUNG"
 .LP
-whohas ist ein Kommandozeilenprogramm, das verfügbare Pakete von Arch, Debian, Fedora, Gentoo, Mandriva, openSUSE, Slackware, Source Mage, Ubuntu, FreeBSD, NetBSD, OpenBSD, Fink, MacPorts und Cygwin findet, die einem Suchbegriff entsprechen.
+whohas ist ein Kommandozeilenprogramm, das verfügbare Pakete von Arch, Debian, Fedora, Gentoo, Mageia, openSUSE, Slackware, Source Mage, Ubuntu, FreeBSD, NetBSD, OpenBSD, Fink, MacPorts und Cygwin findet, die einem Suchbegriff entsprechen.
 .SH "OPTIONEN"
 .LP
 .TP
@@ -21,7 +21,7 @@ Nur ein Aufruf pro Server. Bietet weniger Informationen, ist aber schneller. Typ
 Listet nur die Pakete, die genau \fIpkgname\fP haben wie ihr Name.
 .TP
 \fB\-d Dist1[,Dist2[,Dist3 etc.]]\fR
-Durchsucht nur aufgelistete Distributionen. Gültige Angaben für Dist1 etc. sind "archlinux", "cygwin", "debian", "fedora", "fink", "freebsd", "gentoo", "macports", "mandriva", "netbsd", "openbsd", "opensuse", "slackware", "sourcemage", und "ubuntu".
+Durchsucht nur aufgelistete Distributionen. Gültige Angaben für Dist1 etc. sind "archlinux", "cygwin", "debian", "fedora", "fink", "freebsd", "gentoo", "macports", "mageia", "netbsd", "openbsd", "opensuse", "slackware", "sourcemage", und "ubuntu".
 .TP
 \fBpkgname\fR
 Suchbegriff

--- a/usr/share/man/man1/whohas.1
+++ b/usr/share/man/man1/whohas.1
@@ -7,7 +7,7 @@ whohas \- find packages in various distributions' repositories
 whohas [\fI\-\-no\-threads\fP] [\fI\-\-shallow\fP] [\fI\-\-strict\fP] [\fI\-d Dist1[,Dist2[,Dist3 etc.]]\fP] \fIpkgname\fP
 .SH "DESCRIPTION"
 .LP
-whohas is a command line tool to query package lists from the Arch, Debian, Fedora, Gentoo, Mandriva, openSUSE, Slackware, Source Mage, Ubuntu, FreeBSD, NetBSD, OpenBSD, Fink, MacPorts and Cygwin distributions.
+whohas is a command line tool to query package lists from the Arch, Debian, Fedora, Gentoo, Mageia, openSUSE, Slackware, Source Mage, Ubuntu, FreeBSD, NetBSD, OpenBSD, Fink, MacPorts and Cygwin distributions.
 .SH "OPTIONS"
 .LP
 .TP
@@ -21,7 +21,7 @@ Limit to one call per server. Faster, but loses some information, typically pack
 List only those packages that have exactly \fIpkgname\fP as their name.
 .TP
 \fB\-d Dist1[,Dist2[,Dist3 etc.]]\fR
-Queries only for packages for the listed distributions. Recognised values for Dist1, Dist2, etc. are "archlinux", "cygwin", "debian", "fedora", "fink", "freebsd", "gentoo", "mandriva", "macports", "netbsd", "openbsd", "opensuse", "slackware", "sourcemage", and "ubuntu".
+Queries only for packages for the listed distributions. Recognised values for Dist1, Dist2, etc. are "archlinux", "cygwin", "debian", "fedora", "fink", "freebsd", "gentoo", "mageia", "macports", "netbsd", "openbsd", "opensuse", "slackware", "sourcemage", and "ubuntu".
 .TP
 \fBpkgname\fR
 Package name to query for

--- a/whohas
+++ b/whohas
@@ -62,7 +62,7 @@ our $debian_current_release	 = "all"		;
 our $ubuntu_current_release	 = "all"		;
 our $openbsd_release		 = ""		;
 
-my @distrosAvailable = qw(arch cygwin debian fedora fink freebsd gentoo macports mandriva netbsd openbsd opensuse slack sourcemage ubuntu);
+my @distrosAvailable = qw(arch cygwin debian fedora fink freebsd gentoo macports mageia netbsd openbsd opensuse slack sourcemage ubuntu);
 my %distrosSelected;
 foreach (@distrosAvailable) {
 	$distrosSelected{$_} = 1;
@@ -1346,7 +1346,7 @@ sub template_listing {
 	return ();
 }
 
-sub mandriva_combos {
+sub mageia_combos {
 	$_[0] =~ s/\<\/a\>.*//;
 	my @parts = split /-/, $_[0];
 	for (my $i = 1; $i < @parts; $i++) {
@@ -1356,7 +1356,7 @@ sub mandriva_combos {
 	}
 }
 
-sub mandriva {
+sub mageia {
 	my $baseurl = "http://sophie.zarb.org";
 	my @names;
 	my @versions;
@@ -1365,18 +1365,18 @@ sub mandriva {
 	my @repos;
 	my @urls;
 	# NB this server also supports exact matching
-	my @lines = split /\n/, &fetchdoc($baseurl."/search?search=".$_[0]."&type=fuzzyname&deptype=P&distribution=Mandriva&release=current");
+	my @lines = split /\n/, &fetchdoc($baseurl."/search?search=".$_[0]."&type=fuzzyname&deptype=P&distribution=Mageia&release=cauldron");
 	for (my $i = 350; $i < @lines; $i++) {
 		#TODO need to check for possible further pages (lists 20 per page)
 		#TODO ajax or xml::rpc access might have advantages w.r.t. paging (i.e. none required) 
 		if ($lines[$i] =~ /<div class="sophie_search_list">/) {
 			my $a = @names;
 			push @urls, (split /"/, $lines[$i+1])[1];
-			($names[$a],$versions[$a]) = &mandriva_combos($lines[$i+2]); # name, version, arch
+			($names[$a],$versions[$a]) = &mageia_combos($lines[$i+2]); # name, version, arch
 		}
 	}
 	for (my $i = 0; $i < @urls; $i++) {
-		&pretty_print($cols,@columns,"Mandriva",$names[$i],$versions[$i],$sizes[$i],$dates[$i],$repos[$i],$urls[$i]);
+		&pretty_print($cols,@columns,"Mageia",$names[$i],$versions[$i],$sizes[$i],$dates[$i],$repos[$i],$urls[$i]);
 	}
 	return ();
 }

--- a/whohas.cf
+++ b/whohas.cf
@@ -22,6 +22,6 @@
 #
 # Inclusion of distributions.
 #
-#@distroSelections = qw(arch cygwin debian fedora fink freebsd gentoo macports mandriva netbsd openbsd opensuse slack sourcemage ubuntu);
+#@distroSelections = qw(arch cygwin debian fedora fink freebsd gentoo macports mageia netbsd openbsd opensuse slack sourcemage ubuntu);
 
 1;


### PR DESCRIPTION
Mandriva is dead, there are successors like Mageia, OpenMandriva and ROSA.

It is cheap to replace Mandriva with Mageia since sophie.zarb.org used to fetch Mandriva packages supports Mageia, as well, we should only modify the search string.